### PR TITLE
Fixed Typos. Adding a second example to function: fullname in default…

### DIFF
--- a/default-parameters.md
+++ b/default-parameters.md
@@ -11,18 +11,19 @@ const ex2 = addToFive(5);
 console.log(ex1, ex2); // 5, 10
 
 function fullname ({firstname, lastname}) {
-	return `${firstname lastname}`;
+	return `${firstname} ${lastname}`;
 }
 const user = { firstname: 'Theodore', lastname: 'Logan', age: '20' };
 const fullname = fullname(user);
-console.log(`Hello ${fullname}`);
+console.log(`Hello ${fullname}`); //Hello Theodore Logan
 ```
 
 When destructuring you can also assign defaults.
 
 ```js
 function myFunc({age = 42}) {
-	console.log(age); // 42
+	console.log(age); 
 };
-myFunc({name: 'Theodor'});
+myFunc({name: 'Theodore'}); //42
+myFunc({name: 'Theodore', age: 30}); //30
 ```

--- a/promises.md
+++ b/promises.md
@@ -59,7 +59,7 @@ callToDb('table_name')
 
 Chains can be as long as you need them. `catch` can also be used multiple 
 times in a promise chain, the next `catch` in the chain is called on return 
-of an `Error` and following `then`s will still be called.
+of an `Error` and following `then` blocks will still be called.
 
 ```js
 

--- a/variables.md
+++ b/variables.md
@@ -18,7 +18,7 @@ There are rules for naming the variable identifier. These are:
 - can be alphanumeric, although cannot start with a number
 - `$` and `_` are also allowed characters for an identifier
 
-Variables decalred by `var` have the scope of the entire function.
+Variables declared by `var` have the scope of the entire function.
 
 ```js
 function myFunc() {
@@ -69,7 +69,7 @@ version = '0.0.2'; // TypeError: invalid assignment to const
 const name = 'bill';
 const name = 'ted'; // SyntaxError: Identifier 'name' has already been declared
 ```
-Variables decalred by `const` (constants) cannot be changed. However, with a 
+Variables declared by `const` (constants) cannot be changed. However, with a 
 for loop the scope is redeclared at the start of each loop, where a new 
 `const` can be initalized.
 


### PR DESCRIPTION
Fixed Typos. 
Added a second example to function: fullname in default-parameters for contrast. 
Fixed return statement in function: fullname

* **Docs have been updated for typos
