### PR TITLE
 Changed code block notation to runkit executable block for variable.md

### DIFF
--- a/variables.md
+++ b/variables.md
@@ -1,18 +1,26 @@
+
 # ES6 Variables
 
 
 ## `var` vs `let`
 A variable in javascript is a named space in memory. Traditionally the keyword
 `var` initializes the `identifier` with a `value`:
+ 
 
-```js
+{% runkit %}
+ 
 var	my_variable	=	'value';
 //1	//2			//3 
 
 //1 the var keyword
 //2 the identifier
 //3 the value
-```
+
+
+{% endrunkit %} 
+
+
+
 There are rules for naming the variable identifier. These are:
 - identifiers cannot be keywords
 - can be alphanumeric, although cannot start with a number
@@ -20,32 +28,37 @@ There are rules for naming the variable identifier. These are:
 
 Variables declared by `var` have the scope of the entire function.
 
-```js
+{% runkit %}
 function myFunc() {
 	if(true) {
 		var my_var = 'test';
 	}
 	console.log(my_var); // test
 }
-```
+
+myFunc();
+
+{% endrunkit %} 
 
 ## The `let` keyword
 
 `let` is preferred over `var`. Variables declared by `let` have their scope
 within the `block` they are defined.
 
-```js
+{% runkit %}
 function myFunc() {
 	if(true) {
 		let my_var = 'test';
 	}
 	console.log(my_var); // TypeError
 }
-```
+
+myFunc();
+{% endrunkit %} 
 
 Block scoping allows for variable [`shadowing`][Shadowing].
 
-```js
+{% runkit %}
 function myFunc() {
 	let my_var = 'test';
 	if(true) {
@@ -54,7 +67,9 @@ function myFunc() {
 	}
 	console.log(my_var); // test
 }
-```
+
+myFunc();
+{% endrunkit %}
 
 ## The `const` keyword
 
@@ -62,18 +77,18 @@ ES6 also introduced a new variable keyword: `const`. Variables declared with
 the `const` keyword are block scoped just like `let` however they cannot 
 change by reassignment and they cannot be re-declared; they are immutable.
 
-```js
+{% runkit %}
 const version = '0.0.1';
 version = '0.0.2'; // TypeError: invalid assignment to const
 
 const name = 'bill';
 const name = 'ted'; // SyntaxError: Identifier 'name' has already been declared
-```
+{% endrunkit %}
 Variables declared by `const` (constants) cannot be changed. However, with a 
 for loop the scope is redeclared at the start of each loop, where a new 
 `const` can be initalized.
 
-```js 
+{% runkit %}
 
 function myFunc(items) {
 	for(let i = 0; i < items.length; i++) {
@@ -83,6 +98,8 @@ function myFunc(items) {
 }
 
 myFunc(['test', 100, 200]);
-```
+
+{% endrunkit %}
 
 [Shadowing]: https://en.wikipedia.org/wiki/Variable_shadowing
+


### PR DESCRIPTION
Please make sure that github dont support {% runkit %} tag but dev.to does, so change any occurence of markdown code block to runkit.

this is actual template.

{% runkit
// hidden setup JavaScript code goes in this preamble area
const hiddenVar = 42
%}
// visible, reader-editable JavaScript code goes here
console.log(hiddenVar)
{% endrunkit %} 

Thank you for the great article once again, I wish i had time contributing to this.



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
